### PR TITLE
Maintains sort order when navigating away from engineers view

### DIFF
--- a/app/src/main/java/com/glucode/about_you/data/EngineersRepository.kt
+++ b/app/src/main/java/com/glucode/about_you/data/EngineersRepository.kt
@@ -5,7 +5,15 @@ import com.glucode.about_you.engineers.models.QuickStats
 
 object EngineersRepository {
     private val _engineers = mutableListOf<Engineer>()
-    val engineers: List<Engineer> = _engineers
+    private var _quickStatSelector: ((QuickStats) -> Int)? = null
+
+    val engineers: List<Engineer>
+        get() = _quickStatSelector?.let { selector ->
+            _engineers.sortedBy { selector(it.quickStats) }
+        } ?: _engineers
+
+    val unsortedEngineers: List<Engineer> = _engineers
+
 
     fun init(initialEngineers: List<Engineer>) {
         _engineers.clear()
@@ -17,7 +25,7 @@ object EngineersRepository {
         engineer?.defaultImageName = imageName
     }
 
-    fun byQuickStatAsc(quickStatSelector: (QuickStats) -> Int): List<Engineer> {
-        return engineers.sortedBy { quickStatSelector(it.quickStats) }
+    fun sortByQuickStatAsc(quickStatSelector: (QuickStats) -> Int) {
+        _quickStatSelector = quickStatSelector
     }
 }

--- a/app/src/main/java/com/glucode/about_you/engineers/EngineersFragment.kt
+++ b/app/src/main/java/com/glucode/about_you/engineers/EngineersFragment.kt
@@ -33,23 +33,18 @@ class EngineersFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.action_years -> {
-                updateAfterEngineersListSorted(EngineersRepository.byQuickStatAsc { it.years })
-                return true
+                EngineersRepository.sortByQuickStatAsc { it.years }
             }
             R.id.action_coffees -> {
-                updateAfterEngineersListSorted(EngineersRepository.byQuickStatAsc { it.coffees })
+                EngineersRepository.sortByQuickStatAsc { it.coffees }
                 return true
             }
             R.id.action_bugs -> {
-                updateAfterEngineersListSorted(EngineersRepository.byQuickStatAsc { it.bugs })
-                return true
+                EngineersRepository.sortByQuickStatAsc { it.bugs }
             }
         }
+        setUpEngineersList(EngineersRepository.engineers)
         return super.onOptionsItemSelected(item)
-    }
-
-    private fun updateAfterEngineersListSorted(engineers: List<Engineer>) {
-        setUpEngineersList(engineers)
     }
 
     private fun setUpEngineersList(engineers: List<Engineer>) {

--- a/app/src/test/java/com/glucode/about_you/EngineersRepositoryTest.kt
+++ b/app/src/test/java/com/glucode/about_you/EngineersRepositoryTest.kt
@@ -40,40 +40,40 @@ class EngineersRepositoryTest {
     }
 
     @Test
-    fun `byQuickStatAsc sorts by years ascending`() {
-        val sortedByYears = EngineersRepository.byQuickStatAsc { it.years }
+    fun `sortByQuickStatAsc sorts by years ascending`() {
+        EngineersRepository.sortByQuickStatAsc { it.years }
 
         val expectedOrder = listOf("Bob", "Alice", "Charlie")
-        val actualOrder = sortedByYears.map { it.name }
+        val actualOrder = EngineersRepository.engineers.map { it.name }
 
         assertEquals(expectedOrder, actualOrder)
     }
 
     @Test
-    fun `byQuickStatAsc sorts by coffees ascending`() {
-        val sortedByCoffees = EngineersRepository.byQuickStatAsc { it.coffees }
+    fun `sortByQuickStatAsc sorts by coffees ascending`() {
+        EngineersRepository.sortByQuickStatAsc { it.coffees }
 
         val expectedOrder = listOf("Alice", "Charlie", "Bob")
-        val actualOrder = sortedByCoffees.map { it.name }
+        val actualOrder = EngineersRepository.engineers.map { it.name }
 
         assertEquals(expectedOrder, actualOrder)
     }
 
     @Test
-    fun `byQuickStatAsc sorts by bugs ascending`() {
-        val sortedByBugs = EngineersRepository.byQuickStatAsc { it.bugs }
+    fun `sortByQuickStatAsc sorts by bugs ascending`() {
+        EngineersRepository.sortByQuickStatAsc { it.bugs }
 
         val expectedOrder = listOf("Charlie", "Bob", "Alice")
-        val actualOrder = sortedByBugs.map { it.name }
+        val actualOrder = EngineersRepository.engineers.map { it.name }
 
         assertEquals(expectedOrder, actualOrder)
     }
 
     @Test
-    fun `byQuickStatAsc does not update the original data`() {
+    fun `byQuickStatAsc does not change the original data`() {
         val expectedOrder = listOf("Alice", "Bob", "Charlie");
-        EngineersRepository.byQuickStatAsc { it.bugs }
-        val actualOrder = EngineersRepository.engineers.map { it.name }
+        EngineersRepository.sortByQuickStatAsc { it.bugs }
+        val actualOrder = EngineersRepository.unsortedEngineers.map { it.name }
         assertEquals(expectedOrder, actualOrder)
     }
 }


### PR DESCRIPTION
Saves the selector to engineers repository and returns a copy of the sorted list